### PR TITLE
Now offering a non-blocking initialization process

### DIFF
--- a/djangodoo/__init__.py
+++ b/djangodoo/__init__.py
@@ -2,6 +2,7 @@
 from django.conf import settings
 from django.db.models.signals import class_prepared
 from django.core.mail import send_mail
+
 import erppeek
 from .fields import convert_field
 import logging
@@ -10,6 +11,7 @@ from time import sleep
 import traceback
 
 logger = logging.getLogger(__name__)
+VERSION = "0.3.0"
 
 
 def set_auth_cache():
@@ -21,7 +23,12 @@ def set_auth_cache():
 def set_odoo_client():
     config = getattr(settings, "ODOO_HOST", False)
 
-    logger.info("Setting up the Odoo client...")
+    if not config:
+        raise RuntimeError("You need to define ODOO_HOST in your settings in order to use Djangodoo.")
+    elif not config.get("HOST", None):
+        raise RuntimeError("You need to provide a HOST location in ODOO_HOST in order to use Djangodoo.")
+
+    logger.info("Setting up the Odoo client (djangodoo version {})...".format(VERSION))
     max_retry_attempts = getattr(settings, "ODOO_MAX_RETRY_ATTEMPTS", 3)
     retry_delay = getattr(settings, "ODOO_RETRY_DELAY", 5)
 
@@ -44,11 +51,11 @@ def set_odoo_client():
                 logger.error('Unable to connect to a running Odoo server. Aborting.')
                 mail_config = getattr(settings, "ODOO_EMAIL_NOTIFICATION", False)
                 mail_content = """Unable to connect to a running Odoo server. Your application may have failed to start up due to a connection problem with an Odoo instance.
-                
+
                 Djangodoo tried to reconnect {} times, waiting {} seconds between each attempt. Still, the server could not be reached.
 
                 The problem occured with the following host configuration:
-                    
+
                     USER: {}
                     HOST: {}
                     PORT: {}
@@ -58,14 +65,15 @@ def set_odoo_client():
 
 
                 {}
-                    
+
+
                 """.format(max_retry_attempts, retry_delay, config['USER'], config['HOST'], config['PORT'], config['DB'], traceback.format_exc())
                 html_content = """<p>Unable to connect to a running Odoo server. Your application may have failed to start up due to a connection problem with an Odoo instance.</p>
-                
+
                 <p>Djangodoo tried to reconnect <b>{} times</b>, waiting <b>{} seconds</b> between each attempt. Still, the server could not be reached.</p>
 
                 <p>The problem occured with the following host configuration:</p>
-                
+
                 <div style="border-left: 1px solid gray; padding-left: 10px;">
                     USER: {}<br>
                     HOST: {}<br>
@@ -80,7 +88,7 @@ def set_odoo_client():
                 {}
 
                 </pre>
-                    
+
                 """.format(max_retry_attempts, retry_delay, config['USER'], config['HOST'], config['PORT'], config['DB'], traceback.format_exc())
                 if mail_config:
                     logger.info('Sending an email notification to the administrator...')
@@ -90,7 +98,6 @@ def set_odoo_client():
                         mail_config["RECIPIENTS"],
                         html_message=html_content,
                         fail_silently=False)
-                raise
 
     _connect(0)
 
@@ -100,14 +107,26 @@ def add_extra_model_fields(sender, **kwargs):
 
         The fields are "translated" by using the definitions in fields
     """
+    odoo = getattr(settings, "odoo", None)
+
     def add_field(django_model, field_details):
         odoo_field = convert_field(field_details)
         if odoo_field:
             field = odoo_field.to_django()
             field.contribute_to_class(django_model, field_details['name'])
 
-    odoo = settings.odoo
     if getattr(sender, "_odoo_model", False):
+        # This means we are dealing with an OdooModel
+        if not odoo:
+            # This means set_odoo_client() failed to establish the connexion.
+            # There is no point in proceeding any further as this would raise
+            # an exception that will block the entire application.
+            #TODO handle the case properly instead of bypassing the model generation
+            host = getattr(settings, "ODOO_HOST", False).get("HOST", None)
+            err_msg = """The model named {} could not be processed by Djangodoo because the Odoo server at {} could not be reached.""".format(sender.__name__, host)
+            logger.error(err_msg)
+            return
+
         settings.odoo_models[sender._odoo_model] = sender
         _all_fields = odoo.model(sender._odoo_model).fields(sender._get_odoo_fields())
         for fname, fdetails in _all_fields.items():

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,10 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
+
 setup(
     name='djangodoo',
-    version='0.2.5',
+    version="0.3.0",
     packages=['djangodoo'],
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
Following the problem raised in #3, here is a patch that avoids single-point failures in third-party applications. I used a different approach from what was discussed in #3 but it works anyway.
